### PR TITLE
Add multi-strip animator and runtime length support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 - ⚙️ Fully configurable (timings, RGB/RGBW format, GPIO)
 - ✨ Optional `WS2812Strip` C++ class
 - 🌈 Built-in effects with `WS2812Animator`
+- 🎛️ Synchronised multi-strip animations with `WS2812MultiAnimator`
+- 📏 Flexible strip lengths at runtime
 - 🧰 `RmtChannel` RAII helper for the RMT peripheral
 - 👉 Simple API for updating entire LED chains
 - 🔆 Global brightness control
@@ -31,7 +33,8 @@
 │   ├── ws2812_control.c        # Core driver implementation
 │   ├── ws2812_control.h        # C API header
 │   ├── ws2812_cpp.hpp          # Optional C++ wrapper
-│   └── ws2812_effects.hpp      # Basic animation helper
+│   ├── ws2812_effects.hpp      # Basic animation helper
+│   └── ws2812_multi_animator.hpp # Multi-strip animator
 ├── CMakeLists.txt              # Component build configuration
 ├── component.mk                # Legacy build support
 ├── Kconfig                     # Configuration options
@@ -56,6 +59,10 @@
 5. To use built-in animations, also include:
    ```cpp
    #include "ws2812_effects.hpp"
+   ```
+6. For synchronized multi-strip control, include:
+   ```cpp
+   #include "ws2812_multi_animator.hpp"
    ```
 
 ---

--- a/src/ws2812_multi_animator.hpp
+++ b/src/ws2812_multi_animator.hpp
@@ -1,0 +1,59 @@
+#ifndef WS2812_MULTI_ANIMATOR_HPP
+#define WS2812_MULTI_ANIMATOR_HPP
+
+#include "ws2812_effects.hpp"
+#include <vector>
+
+#ifdef __cplusplus
+class WS2812MultiAnimator {
+public:
+    explicit WS2812MultiAnimator(const std::vector<WS2812Strip*>& strips,
+                                 bool unified = true, bool sync = true)
+        : m_sync(sync)
+    {
+        uint32_t maxLen = 0;
+        for (auto* s : strips) {
+            if (s && s->length() > maxLen) {
+                maxLen = s->length();
+            }
+        }
+        for (auto* s : strips) {
+            if (!s) continue;
+            m_animators.emplace_back(*s, unified ? maxLen : 0);
+        }
+    }
+
+    void setEffect(WS2812Animator::Effect eff, uint32_t color = 0xFFFFFF) {
+        for (auto& a : m_animators) {
+            a.setEffect(eff, color);
+        }
+    }
+
+    void setEffect(size_t idx, WS2812Animator::Effect eff, uint32_t color = 0xFFFFFF) {
+        if (idx < m_animators.size()) {
+            m_animators[idx].setEffect(eff, color);
+        }
+    }
+
+    void tick() {
+        if (m_sync) {
+            for (auto& a : m_animators) {
+                a.setStep(m_step);
+            }
+        }
+        for (auto& a : m_animators) {
+            a.tick();
+        }
+        if (m_sync && !m_animators.empty()) {
+            m_step = m_animators.front().step();
+        }
+    }
+
+private:
+    std::vector<WS2812Animator> m_animators;
+    bool m_sync = true;
+    uint16_t m_step = 0;
+};
+#endif // __cplusplus
+
+#endif // WS2812_MULTI_ANIMATOR_HPP


### PR DESCRIPTION
## Summary
- allow `WS2812Strip` to specify LED count at runtime
- lazily initialise hardware from `WS2812Animator`
- add option for virtual length and expose step control
- add `WS2812MultiAnimator` for synchronised multi-strip effects
- document new features
