### PR TITLE
Add runtime configuration to WS2812Strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## 📦 Overview
 
-**HF-WS2812** is a lightweight ESP-IDF component that provides precise timing for WS2812-compatible LED strips via the RMT peripheral. All parameters—including the number of LEDs, timings, and GPIO—are configurable through Kconfig. A minimal C API is provided, with an optional C++ wrapper for easier integration in modern applications.
+**HF-WS2812** is a lightweight ESP-IDF component that provides precise timing for WS2812-compatible LED strips via the RMT peripheral. All parameters can be configured through Kconfig or supplied at runtime through the `WS2812Strip` C++ class. A minimal C API is provided, with an optional C++ wrapper for easier integration in modern applications.
 
 ---
 
@@ -19,6 +19,7 @@
 - 🌈 Built-in effects with `WS2812Animator`
 - 🎛️ Synchronised multi-strip animations with `WS2812MultiAnimator`
 - 📏 Flexible strip lengths at runtime
+- 🔧 All timings and LED type configurable at runtime using `WS2812Strip`
 - 🧰 `RmtChannel` RAII helper for the RMT peripheral
 - 👉 Simple API for updating entire LED chains
 - 🔆 Global brightness control
@@ -91,7 +92,9 @@
 #include "ws2812_cpp.hpp"
 #include "ws2812_effects.hpp"
 
-WS2812Strip strip(GPIO_NUM_18); // runtime pin selection
+// GPIO, RMT channel, number of LEDs and more can be set here
+WS2812Strip strip(GPIO_NUM_18, RMT_CHANNEL_0, 30, LedType::RGB); // runtime config
+// strip.setTimings(custom_t0h, custom_t1h, custom_t0l, custom_t1l); // optional
 WS2812Animator anim(strip);
 
 void app_main(void)
@@ -110,7 +113,7 @@ void app_main(void)
 ```cpp
 static void ledTask(void *)
 {
-    WS2812Strip strip(GPIO_NUM_18);
+    WS2812Strip strip(GPIO_NUM_18, RMT_CHANNEL_0, 30, LedType::RGB);
     WS2812Animator anim(strip);
     strip.begin();
     anim.setEffect(WS2812Animator::Effect::Breath, 0x00FF00);
@@ -141,7 +144,7 @@ void app_main(void)
 ### Virtual Length Example
 
 ```cpp
-WS2812Strip strip(GPIO_NUM_18);
+WS2812Strip strip(GPIO_NUM_18, RMT_CHANNEL_0, 30, LedType::RGB);
 WS2812Animator anim(strip, 60); // animate as if 60 LEDs are connected
 
 void app_main(void)
@@ -194,6 +197,7 @@ void app_main(void)
 | `setPixel(index, color)` | Set individual LED color |
 | `show()` | Transmit buffered colors to the LED chain |
 | `setBrightness(value)` | Set brightness from C++ wrapper |
+| `setTimings(t0h, t1h, t0l, t1l)` | Adjust protocol timings |
 | `length()` | Get the number of LEDs |
 | `colorWheel(pos)` | Convert color wheel position to RGB |
 

--- a/src/ws2812_cpp.hpp
+++ b/src/ws2812_cpp.hpp
@@ -14,14 +14,19 @@
 #include "ws2812_control.h"
 #include "rmt_wrapper.hpp"
 #include <vector>
+#include <cstdint>
 
 #ifdef __cplusplus
+
+/** LED colour encoding. */
+enum class LedType { RGB, RGBW };
 
 /**
  * @brief C++ convenience wrapper for a chain of WS2812 LEDs.
  *
- * The constructor optionally accepts a GPIO number and RMT channel so
- * the strip can be initialised at runtime without changing Kconfig.
+ * All configuration such as GPIO, channel, LED type and timing can be
+ * supplied at runtime via the constructor, allowing multiple strips
+ * with different settings.
  */
 class WS2812Strip {
 public:
@@ -33,9 +38,21 @@ public:
      */
     explicit WS2812Strip(gpio_num_t gpio = (gpio_num_t)CONFIG_WS2812_LED_RMT_TX_GPIO,
                          rmt_channel_t channel = (rmt_channel_t)CONFIG_WS2812_LED_RMT_TX_CHANNEL,
-                         uint32_t numLeds = NUM_LEDS)
+                         uint32_t numLeds = NUM_LEDS,
+#if CONFIG_WS2812_LED_TYPE_RGBW
+                         LedType type = LedType::RGBW,
+#else
+                         LedType type = LedType::RGB,
+#endif
+                         uint16_t t0h = WS2812_T0H,
+                         uint16_t t1h = WS2812_T1H,
+                         uint16_t t0l = WS2812_T0L,
+                         uint16_t t1l = WS2812_T1L,
+                         uint8_t brightness = WS2812_DEFAULT_BRIGHTNESS)
         : m_rmt(gpio, channel), m_gpio(gpio), m_channel(channel), m_numLeds(numLeds),
-          m_pixels(numLeds, 0), m_buffer(numLeds * WS2812_BITS_PER_LED)
+          m_type(type), m_t0h(t0h), m_t1h(t1h), m_t0l(t0l), m_t1l(t1l),
+          m_brightness(brightness),
+          m_pixels(numLeds, 0), m_buffer(numLeds * (type == LedType::RGBW ? 32 : 24))
     {}
 
     /**
@@ -73,6 +90,19 @@ public:
     void setBrightness(uint8_t value) { m_brightness = value; }
 
     /**
+     * @brief Update the bit timing parameters.
+     *
+     * Allows adjustment of the WS2812 protocol timings after construction.
+     */
+    void setTimings(uint16_t t0h, uint16_t t1h, uint16_t t0l, uint16_t t1l)
+    {
+        m_t0h = t0h;
+        m_t1h = t1h;
+        m_t0l = t0l;
+        m_t1l = t1l;
+    }
+
+    /**
      * @brief Generate a colour from a 0-255 position on a colour wheel.
      *
      * @param pos Position on the colour wheel.
@@ -86,8 +116,13 @@ private:
     RmtChannel m_rmt;
     gpio_num_t m_gpio;
     rmt_channel_t m_channel;
-    uint8_t m_brightness = WS2812_DEFAULT_BRIGHTNESS;
-    uint32_t m_numLeds = NUM_LEDS;
+    LedType m_type;
+    uint16_t m_t0h;
+    uint16_t m_t1h;
+    uint16_t m_t0l;
+    uint16_t m_t1l;
+    uint8_t m_brightness;
+    uint32_t m_numLeds;
 };
 
 inline uint32_t WS2812Strip::colorWheel(uint8_t pos)
@@ -106,35 +141,37 @@ inline uint32_t WS2812Strip::colorWheel(uint8_t pos)
 
 inline esp_err_t WS2812Strip::show()
 {
+    uint32_t bitsPerLed = (m_type == LedType::RGBW) ? 32 : 24;
     for (uint32_t led = 0; led < m_numLeds; ++led) {
         uint32_t color = m_pixels[led];
-#if CONFIG_WS2812_LED_TYPE_RGBW
-        uint8_t w = (color >> 24) & 0xFF;
-#endif
         uint8_t r = (color >> 16) & 0xFF;
         uint8_t g = (color >> 8) & 0xFF;
         uint8_t b = color & 0xFF;
+        uint32_t bits = 0;
 
         r = (r * m_brightness) / 255;
         g = (g * m_brightness) / 255;
         b = (b * m_brightness) / 255;
-#if CONFIG_WS2812_LED_TYPE_RGBW
-        w = (w * m_brightness) / 255;
-        uint32_t bits = (w << 24) | (r << 16) | (g << 8) | b;
-#else
-        uint32_t bits = (r << 16) | (g << 8) | b;
-#endif
-        uint32_t mask = 1U << (WS2812_BITS_PER_LED - 1);
-        for (uint32_t bit = 0; bit < WS2812_BITS_PER_LED; ++bit) {
+
+        if (m_type == LedType::RGBW) {
+            uint8_t w = (color >> 24) & 0xFF;
+            w = (w * m_brightness) / 255;
+            bits = (w << 24) | (r << 16) | (g << 8) | b;
+        } else {
+            bits = (r << 16) | (g << 8) | b;
+        }
+
+        uint32_t mask = 1U << (bitsPerLed - 1);
+        for (uint32_t bit = 0; bit < bitsPerLed; ++bit) {
             bool set = bits & mask;
-            m_buffer[led * WS2812_BITS_PER_LED + bit] =
-                set ? (rmt_item32_t){{{WS2812_T1H, 1, WS2812_T1L, 0}}}
-                    : (rmt_item32_t){{{WS2812_T0H, 1, WS2812_T0L, 0}}};
+            m_buffer[led * bitsPerLed + bit] =
+                set ? (rmt_item32_t){{{m_t1h, 1, m_t1l, 0}}}
+                    : (rmt_item32_t){{{m_t0h, 1, m_t0l, 0}}};
             mask >>= 1;
         }
     }
 
-    return m_rmt.transmit(m_buffer.data(), m_numLeds * WS2812_BITS_PER_LED);
+    return m_rmt.transmit(m_buffer.data(), m_numLeds * bitsPerLed);
 }
 
 #endif // __cplusplus


### PR DESCRIPTION
## Summary
- enhance WS2812Strip so LED type and timings can be configured at runtime
- document setTimings method in README and examples

## Testing
- `cmake .` *(fails: Unknown command)*

------
https://chatgpt.com/codex/tasks/task_e_6845aec38b9483288b9fc54bb4e4f3f2